### PR TITLE
cluster error + fix str formatOut

### DIFF
--- a/test.py
+++ b/test.py
@@ -43,7 +43,7 @@ def fetchError(str):
 
 
 def formatOut(str):
-    if (str[-1] == "\n"):
+    if (str.endsWith("\n")):
         str = str[0:-1]
     return str
 
@@ -70,7 +70,7 @@ class TestKmeansMethods(unittest.TestCase):
                 com = runPy(testLine[1:-1])
                 out, err = com
                 outF = formatOut(out.decode("utf-8"))
-                self.assertTrue(testLine[-1].count(str(fetchError(outF))) == 1)
+                self.assertTrue(testLine[-1].count(str(fetchError(outF))) == 0)
 
     def test_properInput(self):
         out1, err1 = runPy([3, 333, 0], FILE11, FILE21)


### PR DESCRIPTION
This test_File seems to be about wrong number of clusters

`formatOut` function gives a return value of 0 for `CLUSTER_ERROR_MSG` and this is valid for the tests

Consider the command line argument requirements:
![image](https://github.com/arel64/HW2_TESTER/assets/43674238/d38359c4-fc06-47a5-a93a-f1cdbfcf87bc)

For tests:
- InvalidClusterLow1 **0** 0.01 [0]
- InvalidClusterHigh1 **100000** 0.01 [0]
- InvalidClusterWithIter1 **100000** 100000 0.01 [0,1]
- InvalidClusterWithValidIter1 **100000** 100 0.01 [0]

the bolded number is the argument passed to k-means++ as K (number of clusters).
Obviously,  K = 0 doesn't satisfy 1 < K so InvalidClusterLow1 should produce an error with  `CLUSTER_ERROR_MSG`  and this is valid (but with assert equal to 1 throws an error).
Likewise for K = 100000 doesn't satisfy K < N, since FILE1 is `input1_db_1.txt` and has N = 100 lines, i.e. observations, thus it should produce an error with  `CLUSTER_ERROR_MSG` as well and this is valid (but with assert equal to 1 throws an error).
